### PR TITLE
notify on active window

### DIFF
--- a/weechat-naughty-notifier.rb
+++ b/weechat-naughty-notifier.rb
@@ -127,7 +127,8 @@ class AwesomeNotifier
         "bg='#{c}',"            +
         "fg='#ffffff',"         +
         "border_width=0,"       +
-        "timeout=#{s}"          +
+        "timeout=#{s},"         +
+        "screen=mouse.screen"   +
       "});"
     )
     IO.popen("awesome-client", "r+") do |ac|


### PR DESCRIPTION
I noticed I also had this change locally. It shows the notification on your currently active screen.
So this is useful for people with multi-monitor setups.